### PR TITLE
Tracking service update

### DIFF
--- a/lib/bluedart/tracking.rb
+++ b/lib/bluedart/tracking.rb
@@ -13,7 +13,7 @@ module Bluedart
     end
 
     def self.request_url
-      'http://www.bluedart.com/servlet/RoutingServlet'
+      'http://api.bluedart.com/servlet/RoutingServlet'
     end
 
     def request
@@ -24,7 +24,7 @@ module Bluedart
     def make_request
       params = {handler: 'tnt', action: 'custawbquery', loginid: @loginid,
         awb: 'awb', numbers: @numbers, lickey: @license_key,
-        verno: 1, scan: @scans
+        verno: 1.3, scan: @scans
       }
       request = HTTParty.get(Tracking.request_url, query: params, verify: false)
       response_return(request.body)

--- a/lib/bluedart/version.rb
+++ b/lib/bluedart/version.rb
@@ -1,3 +1,3 @@
 module Bluedart
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
The server is changed from  ` www.bluedart.com`   to   `api.bluedart.com`  as highlighted below.

http://**api**.bluedart.com/servlet/RoutingServlet?handler=tnt&action=custawbquery&loginid=XXX00001&lickey=xxxxxxxx&**verno=1.3**&awb=awb&format=xml&numbers=6000000001

